### PR TITLE
feature/signup-login

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'io.jsonwebtoken:jjwt-impl:0.11.2'
     implementation 'io.jsonwebtoken:jjwt-jackson:0.11.2'
 

--- a/src/main/java/zerobase/fashionshopapi/config/AppConfig.java
+++ b/src/main/java/zerobase/fashionshopapi/config/AppConfig.java
@@ -1,0 +1,14 @@
+package zerobase.fashionshopapi.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class AppConfig {
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/zerobase/fashionshopapi/config/TestSecurityConfig.java
+++ b/src/main/java/zerobase/fashionshopapi/config/TestSecurityConfig.java
@@ -1,0 +1,21 @@
+package zerobase.fashionshopapi.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+public class TestSecurityConfig {
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(csrf -> csrf.disable()) // Disable CSRF protection for testing
+                .authorizeHttpRequests(auth -> auth.anyRequest().permitAll()); // Allow all requests for testing
+
+        return http.build();
+    }
+}

--- a/src/main/java/zerobase/fashionshopapi/controller/AuthController.java
+++ b/src/main/java/zerobase/fashionshopapi/controller/AuthController.java
@@ -1,0 +1,25 @@
+package zerobase.fashionshopapi.controller;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+import zerobase.fashionshopapi.dto.UserDto;
+import zerobase.fashionshopapi.service.UserService;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+public class AuthController {
+    private final UserService userService;
+
+    @PostMapping("/signup")
+    public ResponseEntity<?> register(@RequestBody @Valid UserDto.SignUp request) {
+        userService.register(request);
+        return ResponseEntity.ok("User registered successfully");
+    }
+
+}

--- a/src/main/java/zerobase/fashionshopapi/controller/AuthController.java
+++ b/src/main/java/zerobase/fashionshopapi/controller/AuthController.java
@@ -1,5 +1,6 @@
 package zerobase.fashionshopapi.controller;
 
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -8,6 +9,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 import zerobase.fashionshopapi.dto.UserDto;
+import zerobase.fashionshopapi.security.TokenProvider;
 import zerobase.fashionshopapi.service.UserService;
 
 @Slf4j
@@ -15,11 +17,41 @@ import zerobase.fashionshopapi.service.UserService;
 @RequiredArgsConstructor
 public class AuthController {
     private final UserService userService;
+    private final TokenProvider tokenProvider;
+    private final HttpServletRequest httpServletRequest; // 현재 요청 정보 (현재 로그인한 정보?)
 
+    // 회원가입
     @PostMapping("/signup")
-    public ResponseEntity<?> register(@RequestBody @Valid UserDto.SignUp request) {
+    public ResponseEntity<?> signUp(@RequestBody @Valid UserDto.SignUp request) {
         userService.register(request);
         return ResponseEntity.ok("User registered successfully");
     }
 
+    // 로그인
+    @PostMapping("/login")
+    public ResponseEntity<?> login(@RequestBody @Valid UserDto.Login request) {
+        UserDto.LoginResponse user = userService.login(request);
+        String token = tokenProvider.generateToken(user.getEmail(), user.getAuthority());
+        log.info("user login -> " + user.getEmail());
+        return ResponseEntity.ok(token);
+    }
+
+    // 로그아웃
+    @PostMapping("/logout")
+    public ResponseEntity<?> logout() {
+        String token = getTokenFromRequest(httpServletRequest);
+        userService.logout(token);
+        return ResponseEntity.ok("User logged out successfully");
+    }
+
+    // 현재 요청 정보에서 jwt 토큰 추출
+    private String getTokenFromRequest(HttpServletRequest request) {
+        // Authorization 헤더에서 토큰 값 추출
+        String bearerToken = request.getHeader("Authorization");
+        if (bearerToken != null && bearerToken.startsWith("Bearer ")) {
+            return bearerToken.substring(7);
+            // "Bearer " 이후의 실체 토큰만 추출
+        }
+        return null;
+    }
 }

--- a/src/main/java/zerobase/fashionshopapi/domain/User.java
+++ b/src/main/java/zerobase/fashionshopapi/domain/User.java
@@ -11,7 +11,6 @@ import zerobase.fashionshopapi.domain.constant.Authority;
 
 import java.util.Collection;
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Entity(name = "User")
 @Getter

--- a/src/main/java/zerobase/fashionshopapi/domain/User.java
+++ b/src/main/java/zerobase/fashionshopapi/domain/User.java
@@ -1,0 +1,85 @@
+package zerobase.fashionshopapi.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import zerobase.fashionshopapi.domain.constant.Authority;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Entity(name = "User")
+@Getter
+@ToString
+@NoArgsConstructor
+public class User implements UserDetails {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true, length = 100)
+    private String email; // 회원 이메일 (고유값)
+
+    @Column(nullable = false)
+    private String username;
+
+    @Column(nullable = false)
+    private String phonenumber;
+
+    @Column(nullable = false)
+    private String password;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Authority authority;
+
+    public User(String email, String username, String phonenumber, String password, Authority authority) {
+        this.email = email;
+        this.username = username;
+        this.phonenumber = phonenumber;
+        this.password = password;
+        this.authority = authority;
+    }
+
+
+    @Override // 권한 반환 : 사용자가 가진 권한
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of(new SimpleGrantedAuthority(authority.name()));
+    }
+
+    @Override // 사용자의 고유한 값 반환 -> 여기선 email 이 고유값이므로 email 반환
+    public String getUsername() {
+        return email;
+    }
+
+    @Override // 사용자의 비밀번호 반환 -> 암호화 되어야 함
+    public String getPassword() {
+        return password;
+    }
+
+    @Override // 계정 만료 여부 반환 : 만료시 false
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override // 계정 잠금 여부 반환 : 잠금시 false
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override // 패스워드 만료 여부 반환 : 만료시 false
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override // 계정 사용 가능 여부 반환 : 사용불가능시 false
+    public boolean isEnabled() {
+        return true;
+    }
+}

--- a/src/main/java/zerobase/fashionshopapi/domain/constant/Authority.java
+++ b/src/main/java/zerobase/fashionshopapi/domain/constant/Authority.java
@@ -1,0 +1,14 @@
+package zerobase.fashionshopapi.domain.constant;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+
+public enum Authority {
+    ROLE_SELLER,
+    ROLE_CUSTOMER;
+
+    // 사용자 문자열 입력을 대문자로 변환 후 Authority enum 객체로 변환
+    @JsonCreator
+    public static Authority fromString(String value) {
+        return Authority.valueOf(value.toUpperCase());
+    }
+}

--- a/src/main/java/zerobase/fashionshopapi/dto/UserDto.java
+++ b/src/main/java/zerobase/fashionshopapi/dto/UserDto.java
@@ -6,7 +6,6 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import zerobase.fashionshopapi.domain.constant.Authority;
 
-import java.util.List;
 
 public class UserDto {
 
@@ -15,7 +14,6 @@ public class UserDto {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class SignUp {
-
         @NotBlank(message = "Email is required")
         @Email(message = "Invalid email format")
         private String email;
@@ -44,11 +42,20 @@ public class UserDto {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class Login {
-
         @NotBlank(message = "Email is required")
         private String email;
 
         @NotBlank(message = "Password is required")
         private String password;
+    }
+
+    // 로그인 응답용 dto (패스워드 리턴은 보안상 이유로 x)
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class LoginResponse {
+        private String email;
+        private String username;
+        private Authority authority;
     }
 }

--- a/src/main/java/zerobase/fashionshopapi/dto/UserDto.java
+++ b/src/main/java/zerobase/fashionshopapi/dto/UserDto.java
@@ -1,0 +1,54 @@
+package zerobase.fashionshopapi.dto;
+
+import jakarta.validation.constraints.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import zerobase.fashionshopapi.domain.constant.Authority;
+
+import java.util.List;
+
+public class UserDto {
+
+    // 회원가입
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class SignUp {
+
+        @NotBlank(message = "Email is required")
+        @Email(message = "Invalid email format")
+        private String email;
+
+        @NotBlank(message = "Username is required")
+        @Size(min = 1, max = 20)
+        private String username;
+
+        @NotBlank(message = "Phone number is required")
+        private String phonenumber;
+
+        @NotBlank(message = "Password is required")
+        @Size(min = 8)
+        @Pattern(
+                regexp ="^(?=.*[A-Za-z])(?=.*\\d)(?=.*[@$!%*#?&])[A-Za-z\\d@$!%*#?&]{8,}$",
+                message = "Password must contain at least one letter, one number, and one special character"
+        )
+        private String password;
+
+        @NotNull(message = "Authority is required")
+        private Authority authority;
+    }
+
+    // 로그인
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class Login {
+
+        @NotBlank(message = "Email is required")
+        private String email;
+
+        @NotBlank(message = "Password is required")
+        private String password;
+    }
+}

--- a/src/main/java/zerobase/fashionshopapi/repository/UserRepository.java
+++ b/src/main/java/zerobase/fashionshopapi/repository/UserRepository.java
@@ -1,0 +1,14 @@
+package zerobase.fashionshopapi.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import zerobase.fashionshopapi.domain.User;
+
+import java.util.Optional;
+
+@Repository
+public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByEmail(String email);
+
+    boolean existsByEmail(String email);
+}

--- a/src/main/java/zerobase/fashionshopapi/security/JwtAuthenticationFilter.java
+++ b/src/main/java/zerobase/fashionshopapi/security/JwtAuthenticationFilter.java
@@ -1,4 +1,58 @@
 package zerobase.fashionshopapi.security;
 
-public class JwtAuthenticationFilter {
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+    private final TokenProvider tokenProvider;
+    private static final String TOKEN_HEADER = "Authorization";
+    private static final String TOKEN_BEARER_PREFIX = "Bearer ";
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        // 1. 헤더에서 jwt 토큰 추출
+        String jwt = getJwtFromRequest(request);
+        log.info("Token from request: {}", jwt);
+
+        // 2. 토큰 유효성 검증
+        if (jwt != null && tokenProvider.validateToken(jwt)) {
+            log.info("Token successfully validated");
+
+            // 3. 객체 생성
+            Authentication auth = tokenProvider.getAuthentication(jwt);
+            log.info("Authentication: {}", auth);
+
+            SecurityContextHolder.getContext().setAuthentication(auth);
+        } else {
+            log.warn("Invalid token");
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private String getJwtFromRequest(HttpServletRequest request) {
+        String bearerToken = request.getHeader(TOKEN_HEADER);
+        log.info("Bearer token: {}", bearerToken);
+        // 현재 들어온 http 요청에서 토큰의 헤더값 추출
+
+        if (bearerToken != null && bearerToken.startsWith(TOKEN_BEARER_PREFIX)) {
+            return bearerToken.substring(TOKEN_BEARER_PREFIX.length());
+        }
+        // 토큰이 비어있지 않은지 + bearer 로 시작하는지 확인
+        // => 조건 만족 시 Bearer 접두사 제거한 실제 토큰 문자열 반환
+        return null;
+    }
 }

--- a/src/main/java/zerobase/fashionshopapi/security/JwtAuthenticationFilter.java
+++ b/src/main/java/zerobase/fashionshopapi/security/JwtAuthenticationFilter.java
@@ -1,0 +1,4 @@
+package zerobase.fashionshopapi.security;
+
+public class JwtAuthenticationFilter {
+}

--- a/src/main/java/zerobase/fashionshopapi/security/SecurityConfiguration.java
+++ b/src/main/java/zerobase/fashionshopapi/security/SecurityConfiguration.java
@@ -1,0 +1,4 @@
+package zerobase.fashionshopapi.security;
+
+public class SecurityConfiguration {
+}

--- a/src/main/java/zerobase/fashionshopapi/security/SecurityConfiguration.java
+++ b/src/main/java/zerobase/fashionshopapi/security/SecurityConfiguration.java
@@ -1,4 +1,43 @@
 package zerobase.fashionshopapi.security;
 
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.stereotype.Service;
+
+@Service
+@Configuration
+@EnableWebSecurity
+@EnableMethodSecurity
+@RequiredArgsConstructor
 public class SecurityConfiguration {
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity httpSecurity) throws Exception {
+        httpSecurity
+                .httpBasic(httpBasic -> httpBasic.disable())
+                .csrf(csrf -> csrf.disable())
+                .sessionManagement(sessionManagement -> sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(authorize -> authorize
+                        .requestMatchers("/signup", "/login", "/logout").permitAll()
+                        .anyRequest().authenticated()
+                )
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+
+        return httpSecurity.build();
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager(HttpSecurity httpSecurity) throws Exception {
+        return httpSecurity.getSharedObject(AuthenticationManager.class);
+    }
+
 }

--- a/src/main/java/zerobase/fashionshopapi/security/TokenProvider.java
+++ b/src/main/java/zerobase/fashionshopapi/security/TokenProvider.java
@@ -1,15 +1,26 @@
 package zerobase.fashionshopapi.security;
 
 import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import zerobase.fashionshopapi.domain.User;
 import zerobase.fashionshopapi.domain.constant.Authority;
+import zerobase.fashionshopapi.repository.UserRepository;
 import zerobase.fashionshopapi.service.UserService;
 
-import java.util.List;
+import java.security.Key;
+import java.util.Date;
 
 @Slf4j
 @Component
@@ -18,6 +29,7 @@ public class TokenProvider {
     private static final String KEY_ROLES = "roles";
     private static final long TOKEN_EXPIRE_TIME = 1000 * 60 * 60 * 5;
     private final UserService userService;
+    private final UserRepository userRepository;
 
     @Value("{jwt.secret}")
     private String secretKey;
@@ -28,8 +40,77 @@ public class TokenProvider {
     // signature : 토큰의 무결성 검증 위해 사용. 헤더와 페이로드를 합쳐서 비밀 키로 서명
     // 토큰 생성 메서드
     public String generateToken(String email, Authority authority) {
-        Claims claims = Jwts.claims().setSubject(email);
+        var now = new Date(); // 현재 시간
+        var expiration = new Date(now.getTime() + TOKEN_EXPIRE_TIME); // 만료 시간
+
+        // 클레임 생성 및 설정
+        Claims claims = Jwts.claims()
+                .setSubject(email);
         claims.put(KEY_ROLES, authority);
+        /*
+         Claim -> jwt 토큰의 페이로드에 포함될 데이터를 담는 객체
+         헤더랑 시그니처는 ? -> jwt 라이브러리에서 자동으로 생성해줌
+         => Jwts.builder() 호출시 자동으로 헤더 생성
+         => signWith() ~ 에서 서명 생성
+         */
+
+        return Jwts.builder()
+                .setClaims(claims)
+                .setIssuedAt(now)
+                .setExpiration(expiration)
+                .signWith(Keys.hmacShaKeyFor(secretKey.getBytes()), SignatureAlgorithm.HS512)
+                .compact();
     }
 
+    public Authentication getAuthentication(String token) {
+        // 인증 객체 생성
+        UserDetails userDetails = userService.loadUserByUsername(getEmail(token));
+        log.info("Authenticated user: {}", userDetails.getUsername());
+        return new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+    }
+
+    public String getEmail(String token) {
+        return parseClaims(token).getSubject();
+    }
+
+    public boolean validateToken(String token) {
+        if (!StringUtils.hasText(token)) {
+            log.warn("Token is empty");
+            return false;
+        }
+        if (userService.isTokenBlackListed(token)) {
+            log.warn("Token is blacklisted");
+            return false;
+        }
+        try {
+            var claims = parseClaims(token);
+            if (claims.getExpiration().before(new Date())) {
+                log.warn("Token is expired");
+                return false;
+            }
+            return true;
+        } catch (Exception e) {
+            log.error("Invalid token : {}", e.getMessage());
+            return false;
+        }
+    }
+
+    // 클레임 객체 추출 및 토큰 유효성 검사
+    public Claims parseClaims(String token) {
+        try {
+            Key key = Keys.hmacShaKeyFor(secretKey.getBytes());
+            return Jwts.parserBuilder() // jwt 토큰을 파싱, 검증하기 위한 파서 객체를 생성하는 빌더 객체 초기화
+                    .setSigningKey(key) // 파서에 서명 검증에 사용할 서명 키 설정
+                    .build() // jwt 토큰을 파싱하는 jwt 토큰 파서 객체 생성 => 토큰 검증 준비 완료
+                    .parseClaimsJws(token) // 주어진 jwt 토큰을 앞서 만든 파서로 파싱하여 클레임 추출 => 서명과 만료시간 모두 검증
+                    .getBody();
+        } catch (ExpiredJwtException e) { // 만료된 토큰인 경우
+            log.error("Expired jwt token : {}", e.getMessage());
+            return e.getClaims(); // 만료된 토큰이어도 클레임 객체 반환
+        } catch (Exception e) { // 이외 잘못된 서명이 있는 토큰이거나 형식이 잘못된 토큰 등등..
+            // jwt 토큰 유효 x 때
+            log.error("Invalid token : {}", e.getMessage());
+            throw new RuntimeException("Invalid token");
+        }
+    }
 }

--- a/src/main/java/zerobase/fashionshopapi/security/TokenProvider.java
+++ b/src/main/java/zerobase/fashionshopapi/security/TokenProvider.java
@@ -1,0 +1,35 @@
+package zerobase.fashionshopapi.security;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import zerobase.fashionshopapi.domain.constant.Authority;
+import zerobase.fashionshopapi.service.UserService;
+
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class TokenProvider {
+    private static final String KEY_ROLES = "roles";
+    private static final long TOKEN_EXPIRE_TIME = 1000 * 60 * 60 * 5;
+    private final UserService userService;
+
+    @Value("{jwt.secret}")
+    private String secretKey;
+
+    // jwt 의 세 부분 : header, payload, signature
+    // header : 토큰의 타입 (jwt) 과 사용된 서명 알고리즘 (HMAC SHA256) 지정
+    // payload : 토큰의 실제 데이터 포함 <- 여기에 claims 포함
+    // signature : 토큰의 무결성 검증 위해 사용. 헤더와 페이로드를 합쳐서 비밀 키로 서명
+    // 토큰 생성 메서드
+    public String generateToken(String email, Authority authority) {
+        Claims claims = Jwts.claims().setSubject(email);
+        claims.put(KEY_ROLES, authority);
+    }
+
+}

--- a/src/main/java/zerobase/fashionshopapi/service/UserService.java
+++ b/src/main/java/zerobase/fashionshopapi/service/UserService.java
@@ -1,0 +1,44 @@
+package zerobase.fashionshopapi.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import zerobase.fashionshopapi.domain.User;
+import zerobase.fashionshopapi.dto.UserDto;
+import zerobase.fashionshopapi.repository.UserRepository;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class UserService implements UserDetailsService {
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    @Override
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+        return userRepository.findByEmail(email)
+                .orElseThrow(() -> new UsernameNotFoundException(email + "user not found"));
+    }
+
+    // 회원가입
+    public UserDto.SignUp register(UserDto.SignUp userDto) {
+        User user;
+        if (userRepository.existsByEmail(userDto.getEmail())) {
+            throw new RuntimeException("This email already in use");
+        }
+
+        String encodingPassword = passwordEncoder.encode(userDto.getPassword());
+
+        user = new User(userDto.getEmail(), userDto.getUsername(),
+                userDto.getPhonenumber(), encodingPassword, userDto.getAuthority());
+        userRepository.save(user);
+        return userDto;
+    }
+
+    // 로그인
+
+}

--- a/src/test/java/zerobase/fashionshopapi/controller/AuthControllerTest.java
+++ b/src/test/java/zerobase/fashionshopapi/controller/AuthControllerTest.java
@@ -1,0 +1,66 @@
+package zerobase.fashionshopapi.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import zerobase.fashionshopapi.dto.UserDto;
+import zerobase.fashionshopapi.service.UserService;
+import zerobase.fashionshopapi.domain.constant.Authority;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(AuthController.class)
+class AuthControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private UserService userService;
+
+    @Test
+    void testRegisterUser_ValidInput() throws Exception {
+        // 유효한 회원가입 요청 생성
+        UserDto.SignUp validSignUpRequest = new UserDto.SignUp(
+                "test@example.com",
+                "username",
+                "1234567890",
+                "Password1@",
+                Authority.ROLE_CUSTOMER
+        );
+
+        // 서비스의 register 메서드가 호출되면 유효한 결과 반환
+        given(userService.register(validSignUpRequest)).willReturn(validSignUpRequest);
+
+        mockMvc.perform(post("/signup")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(validSignUpRequest)))
+                .andExpect(status().isOk()); // 정상적인 요청은 200 OK
+    }
+
+    @Test
+    void testRegisterUser_InvalidEmail() throws Exception {
+        // 유효하지 않은 이메일로 회원가입 요청 생성
+        UserDto.SignUp invalidSignUpRequest = new UserDto.SignUp(
+                "invalid-email", // 유효하지 않은 이메일
+                "username",
+                "1234567890",
+                "Password1@",
+                Authority.ROLE_CUSTOMER
+        );
+
+        mockMvc.perform(post("/signup")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(invalidSignUpRequest)))
+                .andExpect(status().isBadRequest()); // 유효성 검사 실패 시 400 Bad Request
+    }
+}

--- a/src/test/java/zerobase/fashionshopapi/controller/AuthControllerTest.java
+++ b/src/test/java/zerobase/fashionshopapi/controller/AuthControllerTest.java
@@ -1,21 +1,27 @@
 package zerobase.fashionshopapi.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
-import zerobase.fashionshopapi.dto.UserDto;
-import zerobase.fashionshopapi.service.UserService;
+import zerobase.fashionshopapi.config.TestSecurityConfig;
 import zerobase.fashionshopapi.domain.constant.Authority;
+import zerobase.fashionshopapi.dto.UserDto;
+import zerobase.fashionshopapi.security.TokenProvider;
+import zerobase.fashionshopapi.service.UserService;
 
-import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.mockito.Mockito.when;
 
 @WebMvcTest(AuthController.class)
+@Import(TestSecurityConfig.class) // 테스트용 보안 구성 추가
 class AuthControllerTest {
 
     @Autowired
@@ -27,40 +33,40 @@ class AuthControllerTest {
     @MockBean
     private UserService userService;
 
+    @MockBean
+    private TokenProvider tokenProvider; // TokenProvider mock 추가
+
     @Test
-    void testRegisterUser_ValidInput() throws Exception {
-        // 유효한 회원가입 요청 생성
-        UserDto.SignUp validSignUpRequest = new UserDto.SignUp(
-                "test@example.com",
-                "username",
-                "1234567890",
-                "Password1@",
-                Authority.ROLE_CUSTOMER
+    @DisplayName("회원가입 테스트 - 유효한 입력")
+    void testRegister_ValidInput() throws Exception {
+        // Given: 테스트 데이터 준비
+        UserDto.SignUp signUpRequest = new UserDto.SignUp(
+                "test@example.com", "username", "1234567890", "Password1@", Authority.ROLE_CUSTOMER
         );
 
-        // 서비스의 register 메서드가 호출되면 유효한 결과 반환
-        given(userService.register(validSignUpRequest)).willReturn(validSignUpRequest);
+        // When: UserService의 register 메서드를 모킹하여 실행
+        when(userService.register(signUpRequest)).thenReturn(signUpRequest);
 
+        // Then: MockMvc를 이용하여 /signup 엔드포인트 호출 및 검증
         mockMvc.perform(post("/signup")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(validSignUpRequest)))
-                .andExpect(status().isOk()); // 정상적인 요청은 200 OK
+                        .content(objectMapper.writeValueAsString(signUpRequest)))
+                .andExpect(status().isOk()) // HTTP 상태 코드 200 확인
+                .andExpect(content().string("User registered successfully"));
     }
 
     @Test
-    void testRegisterUser_InvalidEmail() throws Exception {
-        // 유효하지 않은 이메일로 회원가입 요청 생성
-        UserDto.SignUp invalidSignUpRequest = new UserDto.SignUp(
-                "invalid-email", // 유효하지 않은 이메일
-                "username",
-                "1234567890",
-                "Password1@",
-                Authority.ROLE_CUSTOMER
+    @DisplayName("회원가입 테스트 - 잘못된 입력")
+    void testRegister_InValidEmail() throws Exception {
+        // given : 이메일 형식 맞지 않는 입력
+        UserDto.SignUp signUpRequest = new UserDto.SignUp(
+                "test.com", "testname", "1234567890", "12345678!@a", Authority.ROLE_SELLER
         );
 
+        // when & then : @valid 애노테이션을 통해 컨트롤러에서 먼저 유효성 검사 -> 400 응답 반환, 서비스까지 도달 x
         mockMvc.perform(post("/signup")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(invalidSignUpRequest)))
-                .andExpect(status().isBadRequest()); // 유효성 검사 실패 시 400 Bad Request
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(signUpRequest)))
+                .andExpect(status().isBadRequest());
     }
 }

--- a/src/test/java/zerobase/fashionshopapi/controller/AuthControllerTest2.java
+++ b/src/test/java/zerobase/fashionshopapi/controller/AuthControllerTest2.java
@@ -1,0 +1,63 @@
+package zerobase.fashionshopapi.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.web.servlet.MockMvc;
+import zerobase.fashionshopapi.domain.User;
+import zerobase.fashionshopapi.domain.constant.Authority;
+import zerobase.fashionshopapi.dto.UserDto;
+import zerobase.fashionshopapi.repository.UserRepository;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class AuthControllerTest2 {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Test
+    @DisplayName("로그인 테스트 - 유효한 입력")
+    void testLogin_ValidInput() throws Exception {
+        // Given: 테스트 사용자 저장
+        User user = new User("test@example.com", "username", "1234567890", passwordEncoder.encode("password"), Authority.ROLE_CUSTOMER);
+        userRepository.save(user);
+
+        UserDto.Login loginRequest = new UserDto.Login("test@example.com", "password");
+
+        // When & Then: 로그인 요청 수행 및 검증
+        mockMvc.perform(post("/login")
+                        .contentType("application/json")
+                        .content(objectMapper.writeValueAsString(loginRequest)))
+                .andExpect(status().isOk())
+                .andExpect(content().string("mock-token"));
+    }
+
+    @Test
+    @DisplayName("로그아웃 테스트")
+    void testLogout() throws Exception {
+        // Given: 로그아웃을 위한 토큰 설정
+        String token = "valid-jwt-token";
+        mockMvc.perform(post("/logout")
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isOk())
+                .andExpect(content().string("User logged out successfully"));
+    }
+}


### PR DESCRIPTION
### 📋 개요 (Summary)

- 회원가입
- 로그인
- 로그아웃 기능 구현

### 💡 변경 사항 (What & Why)

- 회원가입 시 이메일과 비밀번호 형식 제한
- 권한은 list가 아닌, 단일 값만 가지도록 설정

### 🔍 관련 이슈 (Related Issue)

- 테스트 코드 작성 시, test 용 securityconfig 파일과 실제 securityconfig 파일을 각각 이용하는 과정에서 오류 발생

### ✅ 체크리스트 (Checklist)


### 🚀 테스트 결과 (Test Result)

- 컨트롤러단의 테스트 코드(AuthController)로 회원가입 시 이메일/비밀번호 형식 틀릴 시 400 응답 반환하는 것을 확인
- AuthController2 테스트 코드로 실제 security 설정 및 로그인/로그아웃 테스트 시도 -> testSecurityconfig와 겹치는 오류 발생

### 💬 리뷰 요청 / 질문

- testSecurityConfig 와 전체 설정 SecurityConfig 파일을 동시에 두고 테스트를 나누어서 하는 방법이 따로 있을까요? 현재는 두 Security설정에서 securityFilterChain 의 동일한 이름의 빈이 있다고 충돌이 발생합니다.
- AuthController 에서는 test용 security를, AuthController2 에서는 기본 security 설정을 이용하고 싶은데 어떻게 해야 할까요?
