### PR TITLE
feature/logout

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'io.jsonwebtoken:jjwt-impl:0.11.2'
     implementation 'io.jsonwebtoken:jjwt-jackson:0.11.2'
 

--- a/src/main/java/zerobase/fashionshopapi/FashionShopApiApplication.java
+++ b/src/main/java/zerobase/fashionshopapi/FashionShopApiApplication.java
@@ -2,8 +2,10 @@ package zerobase.fashionshopapi;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cache.annotation.EnableCaching;
 
 @SpringBootApplication
+@EnableCaching
 public class FashionShopApiApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/zerobase/fashionshopapi/controller/AuthController.java
+++ b/src/main/java/zerobase/fashionshopapi/controller/AuthController.java
@@ -4,12 +4,13 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 import zerobase.fashionshopapi.dto.UserDto;
-import zerobase.fashionshopapi.security.JwtAuthenticationFilter;
 import zerobase.fashionshopapi.security.TokenProvider;
 import zerobase.fashionshopapi.service.UserService;
 
@@ -19,8 +20,7 @@ import zerobase.fashionshopapi.service.UserService;
 public class AuthController {
     private final UserService userService;
     private final TokenProvider tokenProvider;
-    private final HttpServletRequest httpServletRequest; // 현재 요청 정보 (현재 로그인한 정보?)
-    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+    private final RedisTemplate<String, Object> redisTemplate; // 로그인 하면 redis 에 jwt 토큰 저장
 
     // 회원가입
     @PostMapping("/signup")
@@ -32,11 +32,31 @@ public class AuthController {
     // 로그인
     @PostMapping("/login")
     public ResponseEntity<?> login(@RequestBody @Valid UserDto.Login request) {
+        // 이미 로그인된 사용자인지 확인
+        String existingToken = (String) redisTemplate.opsForValue().get("JWT:" + request.getEmail());
+        if (existingToken != null) {
+            return ResponseEntity.status(HttpStatus.CONFLICT).body("User is already logged in");
+        }
+
         UserDto.LoginResponse user = userService.login(request);
         String token = tokenProvider.generateToken(user.getEmail(), user.getAuthority());
         log.info("user login -> " + user.getEmail());
+
+        // Redis 에 JWT 토큰 저장
+        redisTemplate.opsForValue().set("JWT:" + user.getEmail(), token);
         return ResponseEntity.ok(token);
     }
 
+    // 로그아웃
+    @PostMapping("/user_logout") ResponseEntity<?> logout(HttpServletRequest request) {
+        // 현재 로그인한 클라이언트의 요청정보 (HttpServletRequest) 에서 jwt 토큰 추출
+        // 유효성 검사는 필터에서 이미 하고 넘어옴
+        String token = request.getHeader("Authorization").substring(7); // "Bearer " 제거
 
+        // Redis 에서 토큰 삭제
+        String email = tokenProvider.getEmail(token);
+        redisTemplate.delete("JWT:" + email);
+
+        return ResponseEntity.ok("Logged out successfully");
+    }
 }

--- a/src/main/java/zerobase/fashionshopapi/security/SecurityConfiguration.java
+++ b/src/main/java/zerobase/fashionshopapi/security/SecurityConfiguration.java
@@ -27,7 +27,8 @@ public class SecurityConfiguration {
                 .csrf(csrf -> csrf.disable())
                 .sessionManagement(sessionManagement -> sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(authorize -> authorize
-                        .requestMatchers("/signup", "/login", "/logout").permitAll()
+                        .requestMatchers("/signup", "/login").permitAll()
+                        .requestMatchers("/logout").authenticated() // 로그아웃 요청은 인증된 사용자만 접근 가능
                         .anyRequest().authenticated()
                 )
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);

--- a/src/main/java/zerobase/fashionshopapi/service/UserService.java
+++ b/src/main/java/zerobase/fashionshopapi/service/UserService.java
@@ -11,8 +11,6 @@ import zerobase.fashionshopapi.domain.User;
 import zerobase.fashionshopapi.dto.UserDto;
 import zerobase.fashionshopapi.repository.UserRepository;
 
-import java.util.HashSet;
-import java.util.Set;
 
 @Slf4j
 @Service

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -13,3 +13,7 @@ spring.jpa.database=mysql
 
 # jwt
 jwt.secret=emVyb2Jhc2Utc3ByaW5nLWJvb3QtZGl2aWRlbmQtcHJvamVjdC10dXRvcmlhbC1qd3Qtc2VjcmV0LWtleQ==
+
+# redis
+spring.data.redis.host=localhost
+spring.data.redis.port=6379


### PR DESCRIPTION
### 📋 개요 (Summary)

- redis 서버 연결
- redis 에 jwt 토큰 저장하는 방식으로 로그아웃 처리

### 💡 변경 사항 (What & Why)

- 로그인 시 -> 이메일로 redis에 이미 저장된 jwt토큰이 있으면 중복 로그인 시도 -> 에러 처리
- 로그아웃 시 -> 로그인 권한 필요 -> 필터에서 redis 검사 -> redis 에 jwt 토큰 있는 경우에만 로그아웃 가능 -> 유효성 검사 통과 시 redis 에서 해당 jwt토큰 삭제

### 🔍 관련 이슈 (Related Issue)

- securityConfig 에서 /signup, /login 만 permit 했는데, 회원가입과 로그인 시도에도 jwt 토큰을 요구함 ..
=> jwtAuthenticationFilter 에서 shouldNotFilter을 추가해서 해결
- /logout 을 post 요청으로 구현했는데 자꾸 get 요청 어쩌구 오류.. => spring boot 에서는 기본으로 제공해주는 /logout url 이 get요청으로 처리됨..(아마도?) => custom 해서 /user_logout 으로 처리 성공

### ✅ 체크리스트 (Checklist)

- [ ] 코드가 정상적으로 작동하는지 확인했습니다.


### 🚀 테스트 결과 (Test Result)

- [ ] postman으로 회원가입 -> 로그인 -> 로그아웃 -> 다시 로그아웃(redis 에서 jwt 토큰 삭제 후 다시 시도 하는 경우) 모두 테스트 완료

### 💬 기타 사항 (Additional Information)

- securityConfig 에서 /signup, /login 만 permit 했는데, 회원가입과 로그인 시도에도 jwt 토큰을 요구함 <- 이 부분이 왜 안되는지 이해가 안됩니다 !! ㅠㅠ jwt filter에 추가해서 해결하긴 했는데, securityConfig에서 permit 하면 유효성 검사 안하는 거 아닌가요?!!

### 추가할 기능
- redis 에 TTL 설정
- 상점 등록, 상품 등록 api