### PR TITLE
feaure/logout2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'io.jsonwebtoken:jjwt-impl:0.11.2'
     implementation 'io.jsonwebtoken:jjwt-jackson:0.11.2'
 

--- a/src/main/java/zerobase/fashionshopapi/FashionShopApiApplication.java
+++ b/src/main/java/zerobase/fashionshopapi/FashionShopApiApplication.java
@@ -2,8 +2,10 @@ package zerobase.fashionshopapi;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cache.annotation.EnableCaching;
 
 @SpringBootApplication
+@EnableCaching
 public class FashionShopApiApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/zerobase/fashionshopapi/controller/AuthController.java
+++ b/src/main/java/zerobase/fashionshopapi/controller/AuthController.java
@@ -5,7 +5,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.http.HttpStatus;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -32,31 +32,18 @@ public class AuthController {
     // 로그인
     @PostMapping("/login")
     public ResponseEntity<?> login(@RequestBody @Valid UserDto.Login request) {
-        // 이미 로그인된 사용자인지 확인
-        String existingToken = (String) redisTemplate.opsForValue().get("JWT:" + request.getEmail());
-        if (existingToken != null) {
-            return ResponseEntity.status(HttpStatus.CONFLICT).body("User is already logged in");
-        }
-
-        UserDto.LoginResponse user = userService.login(request);
-        String token = tokenProvider.generateToken(user.getEmail(), user.getAuthority());
-        log.info("user login -> " + user.getEmail());
-
-        // Redis 에 JWT 토큰 저장
-        redisTemplate.opsForValue().set("JWT:" + user.getEmail(), token);
+        String token = userService.login(request);
         return ResponseEntity.ok(token);
     }
 
     // 로그아웃
-    @PostMapping("/user_logout") ResponseEntity<?> logout(HttpServletRequest request) {
+    @PostMapping("/user_logout")
+    public ResponseEntity<?> logout(HttpServletRequest request) {
         // 현재 로그인한 클라이언트의 요청정보 (HttpServletRequest) 에서 jwt 토큰 추출
         // 유효성 검사는 필터에서 이미 하고 넘어옴
         String token = request.getHeader("Authorization").substring(7); // "Bearer " 제거
 
-        // Redis 에서 토큰 삭제
-        String email = tokenProvider.getEmail(token);
-        redisTemplate.delete("JWT:" + email);
-
+        userService.logout(token);
         return ResponseEntity.ok("Logged out successfully");
     }
 }

--- a/src/main/java/zerobase/fashionshopapi/controller/AuthController.java
+++ b/src/main/java/zerobase/fashionshopapi/controller/AuthController.java
@@ -4,12 +4,13 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 import zerobase.fashionshopapi.dto.UserDto;
-import zerobase.fashionshopapi.security.JwtAuthenticationFilter;
 import zerobase.fashionshopapi.security.TokenProvider;
 import zerobase.fashionshopapi.service.UserService;
 
@@ -19,8 +20,7 @@ import zerobase.fashionshopapi.service.UserService;
 public class AuthController {
     private final UserService userService;
     private final TokenProvider tokenProvider;
-    private final HttpServletRequest httpServletRequest; // 현재 요청 정보 (현재 로그인한 정보?)
-    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+    private final RedisTemplate<String, Object> redisTemplate; // 로그인 하면 redis 에 jwt 토큰 저장
 
     // 회원가입
     @PostMapping("/signup")
@@ -32,11 +32,31 @@ public class AuthController {
     // 로그인
     @PostMapping("/login")
     public ResponseEntity<?> login(@RequestBody @Valid UserDto.Login request) {
+        // 이미 로그인된 사용자인지 확인
+        String existingToken = (String) redisTemplate.opsForValue().get("JWT:" + request.getEmail());
+        if (existingToken != null) {
+            return ResponseEntity.status(HttpStatus.CONFLICT).body("User is already logged in");
+        }
+
         UserDto.LoginResponse user = userService.login(request);
         String token = tokenProvider.generateToken(user.getEmail(), user.getAuthority());
         log.info("user login -> " + user.getEmail());
+
+        // Redis 에 JWT 토큰 저장
+        redisTemplate.opsForValue().set("JWT:" + user.getEmail(), token);
         return ResponseEntity.ok(token);
     }
 
+    // 로그아웃
+    @PostMapping("/user_logout") ResponseEntity<?> logout(HttpServletRequest request) {
+        // 현재 로그인한 클라이언트의 요청정보 (HttpServletRequest) 에서 jwt 토큰 추출
+        // 유효성 검사는 필터에서 이미 하고 넘어옴
+        String token = request.getHeader("Authorization").substring(7); // "Bearer " 제거
 
+        // Redis 에서 토큰 삭제
+        String email = tokenProvider.getEmail(token);
+        redisTemplate.delete("JWT:" + email);
+
+        return ResponseEntity.ok("Logged out successfully");
+    }
 }

--- a/src/main/java/zerobase/fashionshopapi/security/SecurityConfiguration.java
+++ b/src/main/java/zerobase/fashionshopapi/security/SecurityConfiguration.java
@@ -27,7 +27,8 @@ public class SecurityConfiguration {
                 .csrf(csrf -> csrf.disable())
                 .sessionManagement(sessionManagement -> sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(authorize -> authorize
-                        .requestMatchers("/signup", "/login", "/logout").permitAll()
+                        .requestMatchers("/signup", "/login").permitAll()
+                        .requestMatchers("/logout").authenticated() // 로그아웃 요청은 인증된 사용자만 접근 가능
                         .anyRequest().authenticated()
                 )
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);

--- a/src/main/java/zerobase/fashionshopapi/security/TokenProvider.java
+++ b/src/main/java/zerobase/fashionshopapi/security/TokenProvider.java
@@ -26,8 +26,6 @@ import java.util.Date;
 public class TokenProvider {
     private static final String KEY_ROLES = "roles";
     private static final long TOKEN_EXPIRE_TIME = 1000 * 60 * 60 * 5;
-    private final UserService userService;
-    private final UserRepository userRepository;
 
     @Value("${jwt.secret}")
     private String secretKey;
@@ -60,12 +58,6 @@ public class TokenProvider {
                 .compact();
     }
 
-    public Authentication getAuthentication(String token) {
-        // 인증 객체 생성
-        UserDetails userDetails = userService.loadUserByUsername(getEmail(token));
-        log.info("Authenticated user: {}", userDetails.getUsername());
-        return new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
-    }
 
     public String getEmail(String token) {
         return parseClaims(token).getSubject();

--- a/src/main/java/zerobase/fashionshopapi/service/UserService.java
+++ b/src/main/java/zerobase/fashionshopapi/service/UserService.java
@@ -2,6 +2,7 @@ package zerobase.fashionshopapi.service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
@@ -10,6 +11,9 @@ import org.springframework.stereotype.Service;
 import zerobase.fashionshopapi.domain.User;
 import zerobase.fashionshopapi.dto.UserDto;
 import zerobase.fashionshopapi.repository.UserRepository;
+import zerobase.fashionshopapi.security.TokenProvider;
+
+import java.util.concurrent.TimeUnit;
 
 
 @Slf4j
@@ -18,6 +22,8 @@ import zerobase.fashionshopapi.repository.UserRepository;
 public class UserService implements UserDetailsService {
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
+    private final TokenProvider tokenProvider;
+    private final RedisTemplate<String, Object> redisTemplate;
 
     @Override
     public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
@@ -41,17 +47,32 @@ public class UserService implements UserDetailsService {
     }
 
     // 로그인
-    public UserDto.LoginResponse login(UserDto.Login userDto) {
-        // 1. id 존재 여부 확인
+    public String login(UserDto.Login userDto) {
+        // 1. 사용자 인증
         User user = userRepository.findByEmail(userDto.getEmail())
                 .orElseThrow(() -> new UsernameNotFoundException(userDto.getEmail() + "user not found"));
 
-        // 2. id 와 비밀번호 일치하는지 확인
         if (!passwordEncoder.matches(userDto.getPassword(), user.getPassword())) {
             throw new RuntimeException("Wrong password");
         }
 
-        return new UserDto.LoginResponse(user.getEmail(), user.getUsername(), user.getAuthority());
+        // 2. 이미 로그인된 사용자인지 확인
+        String existingToken = (String) redisTemplate.opsForValue().get("JWT:" + user.getEmail());
+        if (existingToken != null) {
+            throw new RuntimeException("User is already logged in");
+        }
+
+        // 3. JWT 토큰 생성 및 Redis 저장
+        String token = tokenProvider.generateToken(user.getEmail(), user.getAuthority());
+        redisTemplate.opsForValue().set("JWT:" + user.getEmail(), token, 5, TimeUnit.HOURS);
+
+        return token; // JWT 토큰 반환
+    }
+
+    // 로그아웃
+    public void logout(String token) {
+        String email = tokenProvider.getEmail(token);
+        redisTemplate.delete("JWT:" + email);
     }
 
 }

--- a/src/main/java/zerobase/fashionshopapi/service/UserService.java
+++ b/src/main/java/zerobase/fashionshopapi/service/UserService.java
@@ -11,8 +11,6 @@ import zerobase.fashionshopapi.domain.User;
 import zerobase.fashionshopapi.dto.UserDto;
 import zerobase.fashionshopapi.repository.UserRepository;
 
-import java.util.HashSet;
-import java.util.Set;
 
 @Slf4j
 @Service

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -13,3 +13,7 @@ spring.jpa.database=mysql
 
 # jwt
 jwt.secret=emVyb2Jhc2Utc3ByaW5nLWJvb3QtZGl2aWRlbmQtcHJvamVjdC10dXRvcmlhbC1qd3Qtc2VjcmV0LWtleQ==
+
+# redis
+spring.data.redis.host=localhost
+spring.data.redis.port=6379


### PR DESCRIPTION
### 📋 개요 (Summary)

- redis ttl 설정 추가
- jwt필터와 securityConfig permit()문제 해결
- 순한의존성문제 해결

### 💡 변경 사항 (What & Why)

-  (토큰 만료시간이 5시간 후라서, redis 에도 저장할 때마다 5시간으로 설정)
- jwt필터에서 유효성 검사 실패 시 응답 반환하고 조기종료 하는 식으로 구현 x -> try-catch 로 유효성 검사 통과 못해도 다음 필터 호출은 하게 만듦
- should not filter 메서드는 일단 추가해둠
- redis 조회, 저장, 삭제를 service 의 메서드에 넣음

### 🔍 관련 이슈 (Related Issue)

- TokenProvider 와 UserService 가 서로를 의존하고 있어서 실행 x => TokenProvider 에서 UserService 의존성 제거 후 코드 수정
=> 해결

### ✅ 체크리스트 (Checklist)

- [ ] 코드가 정상적으로 작동하는지 확인했습니다.

### 🚀 테스트 결과 (Test Result)

- Postman 에서 shouldnotfilter 메서드 없이도 securityConfig 에서 permit한 메서드는 jwt토큰 없이 동작 확인

### 💬 기타 사항 (Additional Information)
